### PR TITLE
v1.2.0 cleanup

### DIFF
--- a/mrna_bench/data_splitter/chromosome_split.py
+++ b/mrna_bench/data_splitter/chromosome_split.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from mrna_bench.data_splitter.data_splitter import DataSplitter
 
+
 class ChromosomeSplitter(DataSplitter):
     """Hold-out chromosome(s) for train-test split."""
 
@@ -12,7 +13,7 @@ class ChromosomeSplitter(DataSplitter):
         test_size: float,
         random_seed: int
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """Split dataframe into train and test split by holding out chromosome(s).
+        """Split dataframe by holding out chromosome(s).
 
         Args:
             df: Dataframe to split.
@@ -26,7 +27,7 @@ class ChromosomeSplitter(DataSplitter):
 
         # Get unique chromosomes and their sizes
         chr_counts = df["chromosome"].value_counts()
-        
+
         # Randomly shuffle chromosomes
         np.random.seed(random_seed)
         chromosomes = chr_counts.index.tolist()
@@ -38,40 +39,51 @@ class ChromosomeSplitter(DataSplitter):
         test_chroms, train_chroms = [], []
         for chr in chromosomes:
             # If adding this chromosome won't exceed target test size, add it
-            if curr_test_size < target_test_size and chr_counts[chr] <= target_test_size - curr_test_size:
+            space = target_test_size - curr_test_size
+            if curr_test_size < target_test_size and chr_counts[chr] <= space:
                 test_chroms.append(chr)
                 curr_test_size += chr_counts[chr]
             # Otherwise, add it to train set
             else:
                 train_chroms.append(chr)
 
-        # If we couldn't get any chromosomes (test_size too small), take smallest chromosome
+        # If we couldn't get any chromosomes (test_size too small),
+        # take smallest chromosome
         chr_counts_sorted = chr_counts.sort_values(ascending=True)
         if not test_chroms:
             test_chroms = [chr_counts_sorted.index[0]]
             train_chroms.remove(test_chroms[0])
-            
+
         # Create train/test split
         test_df = df[df["chromosome"].isin(test_chroms)]
         train_df = df[~df["chromosome"].isin(test_chroms)]
 
-        print("Train chromosomes:", train_chroms, " Test chromosomes:", test_chroms)
-        print("Target test size:", test_size, " Actual test size:", len(test_df)/(len(test_df)+len(train_df)), "\n")
-        
+        chr_out = "Train chromosomes: {}  Test chromosomes: {}"
+        print(chr_out.format(train_chroms, test_chroms))
+
+        # Check if test size is correct
+        actual_ratio = len(test_df) / (len(test_df) + len(train_df))
+        split_size_out = "Train size: {}  Test size: {}"
+        print(split_size_out.format(test_size, actual_ratio))
+
         return train_df, test_df
-    
+
     def _validate_input_df(self, df: pd.DataFrame) -> None:
         """Validate input dataframe for chromosome splitting.
-        
+
         Args:
             df: Input dataframe to validate
-            
+
         Raises:
-            ValueError: If dataframe is empty or contains only one unique chromosome
+            ValueError: If dataframe is empty or contains only one unique
+                chromosome.
         """
         if len(df) == 0:
             raise ValueError("Passed in empty dataframe.")
 
         if len(df["chromosome"].unique()) == 1:
-            raise ValueError("Cannot split data with only one unique chromosome - "
-                           "chromosome-based splitting requires at least 2 different chromosomes")
+            raise ValueError(
+                "Cannot split data with only one unique chromosome - "
+                "chromosome-based splitting requires at least 2 "
+                "different chromosomes"
+            )

--- a/mrna_bench/data_splitter/homology_split.py
+++ b/mrna_bench/data_splitter/homology_split.py
@@ -100,13 +100,15 @@ class HomologySplitter(DataSplitter):
         Args:
             default_split_ratio: Ratio of training, validation, test splits.
             **kwargs: Homology specific arguments:
-                - species: List of species that genes are from.
+                - species: Species that genes are from.
                 - homology_map_path: Path to homology maps.
                 - force_redownload: Forces redownload of homology maps.
         """
         super().__init__(default_split_ratio)
 
-        self.species: list[str] = kwargs["species"]
+        # TODO: Temporary fix for converting species from list to str
+        self.species: list[str] = [kwargs["species"]]
+
         homology_map_path: str | None = kwargs.get("homology_map_path", None)
         force_redownload: bool = kwargs.get("force_redownload", False)
 

--- a/mrna_bench/embedder/dataset_embedder.py
+++ b/mrna_bench/embedder/dataset_embedder.py
@@ -171,7 +171,7 @@ class KmerDatasetEmbedder(DatasetEmbedder):
     whereas s_chunk denotes the sequence chunking that occur within each model
     to handle sequences that exceed model maximum length.
 
-    This class specifically handles
+    This class specifically handles the naive Kmer embedding model.
     """
 
     def __init__(
@@ -181,6 +181,14 @@ class KmerDatasetEmbedder(DatasetEmbedder):
         d_chunk_ind: int = 0,
         d_num_chunks: int = 0
     ):
+        """Initialize KmerDatasetEmbedder.
+
+        Args:
+            model: Model used to embed sequences.
+            dataset: Dataset to embed.
+            d_chunk_ind: Current dataset chunk to be processed.
+            d_num_chunks: Total number of chunks to divide dataset into.
+        """
         super().__init__(model, dataset, d_chunk_ind, d_num_chunks)
 
     def embed_dataset(self) -> torch.Tensor:
@@ -200,11 +208,11 @@ class KmerDatasetEmbedder(DatasetEmbedder):
         self,
         embeddings: torch.Tensor,
     ) -> torch.Tensor:
-        """Removes rows with 0s across all columns and
-        scales the embeddings.
+        """Remove rows with 0s across all columns and scales the embeddings.
 
         Args:
             embeddings: Embeddings to desparsify.
+
         Returns:
             Desparsified embeddings.
         """

--- a/mrna_bench/linear_probe/linear_probe.py
+++ b/mrna_bench/linear_probe/linear_probe.py
@@ -110,21 +110,24 @@ class LinearProbe:
 
         splits = {
             "train_X": np.array(train_df["embeddings"].tolist()),
-            "val_X": np.array(val_df["embeddings"].tolist()),
-            "test_X": np.array(test_df["embeddings"].tolist()),
             "train_y": train_df[self.target_col].to_numpy(),
-            "val_y": val_df[self.target_col].to_numpy(),
-            "test_y": test_df[self.target_col].to_numpy(),
         }
+
+        if not val_df.empty:
+            splits["val_X"] = np.array(val_df["embeddings"].tolist())
+            splits["val_y"] = val_df[self.target_col].to_numpy()
+
+        if not test_df.empty:
+            splits["test_X"] = np.array(test_df["embeddings"].tolist())
+            splits["test_y"] = test_df[self.target_col].to_numpy()
 
         if isinstance(splits["train_y"][0], np.ndarray):
             splits["train_y"] = np.vstack(list(splits["train_y"]))
-            splits["val_y"] = np.vstack(list(splits["val_y"]))
-            splits["test_y"] = np.vstack(list(splits["test_y"]))
-        else:
-            splits["train_y"] = splits["train_y"]
-            splits["val_y"] = splits["val_y"]
-            splits["test_y"] = splits["test_y"]
+
+            if "val_y" in splits:
+                splits["val_y"] = np.vstack(list(splits["val_y"]))
+            if "test_y" in splits:
+                splits["test_y"] = np.vstack(list(splits["test_y"]))
 
         return splits
 

--- a/mrna_bench/linear_probe/linear_probe_builder.py
+++ b/mrna_bench/linear_probe/linear_probe_builder.py
@@ -239,9 +239,9 @@ class LinearProbeBuilder:
             self.persister = LinearProbePersister(
                 self.dataset,
                 self.model_short_name,
-                self.split_type,
+                self.task,
                 self.target_col,
-                self.task
+                self.split_type
             )
 
         return LinearProbe(

--- a/mrna_bench/linear_probe/linear_probe_builder.py
+++ b/mrna_bench/linear_probe/linear_probe_builder.py
@@ -133,6 +133,8 @@ class LinearProbeBuilder:
         Returns:
             LinearProbeBuilder with set embeddings.
         """
+        embedding_name = embedding_name.replace(".npz", "")
+
         emb_fn_arr = embedding_name.split("_")
 
         self.model_short_name = emb_fn_arr[1]

--- a/mrna_bench/models/dnabert.py
+++ b/mrna_bench/models/dnabert.py
@@ -44,18 +44,18 @@ class DNABERT2(EmbeddingModel):
             raise ValueError("Only dnabert2 model version available.")
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            "zhihan1996/DNABERT-2-117M",
+            "quietflamingo/dnabert2-fixed",
             trust_remote_code=True,
             cache_dir=get_model_weights_path()
         )
 
         config = BertConfig.from_pretrained(
-            "zhihan1996/DNABERT-2-117M",
+            "quietflamingo/dnabert2-fixed",
             cache_dir=get_model_weights_path()
         )
 
         self.model = AutoModel.from_pretrained(
-            "zhihan1996/DNABERT-2-117M",
+            "quietflamingo/dnabert2-fixed",
             trust_remote_code=True,
             cache_dir=get_model_weights_path(),
             config=config

--- a/mrna_bench/models/dnabert.py
+++ b/mrna_bench/models/dnabert.py
@@ -44,18 +44,18 @@ class DNABERT2(EmbeddingModel):
             raise ValueError("Only dnabert2 model version available.")
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            "quietflamingo/dnabert2-fixed",
+            "quietflamingo/dnabert2-no-flashattention",
             trust_remote_code=True,
             cache_dir=get_model_weights_path()
         )
 
         config = BertConfig.from_pretrained(
-            "quietflamingo/dnabert2-fixed",
+            "quietflamingo/dnabert2-no-flashattention",
             cache_dir=get_model_weights_path()
         )
 
         self.model = AutoModel.from_pretrained(
-            "quietflamingo/dnabert2-fixed",
+            "quietflamingo/dnabert2-no-flashattention",
             trust_remote_code=True,
             cache_dir=get_model_weights_path(),
             config=config

--- a/mrna_bench/models/dnabert_s.py
+++ b/mrna_bench/models/dnabert_s.py
@@ -7,10 +7,10 @@ from mrna_bench.models import EmbeddingModel
 
 
 class DNABERTS(EmbeddingModel):
-    """Inference wrapper for DNA-BERT2.
+    """Inference wrapper for DNABERT-S.
 
     DNABERT-S is a transformer-based DNA foundation model that builds on
-    DNABERTS to produce species-aware embeddings for genomic sequences.
+    DNABERT-S to produce species-aware embeddings for genomic sequences.
     It is trained using a contrastive learning objective which encourages
     grouping of DNA sequences from the same species and discourages grouping
     of sequences from different species. DNABERT-S is trained using microbial
@@ -25,7 +25,7 @@ class DNABERTS(EmbeddingModel):
         return model_version
 
     def __init__(self, model_version: str, device: torch.device):
-        """Initialize DNABERTS inference wrapper.
+        """Initialize DNABERT-S inference wrapper.
 
         Args:
             model_version: Version of model used; must be "dnabert-s".
@@ -35,51 +35,39 @@ class DNABERTS(EmbeddingModel):
 
         try:
             from transformers import AutoTokenizer, AutoModel
-            from transformers.models.bert.configuration_bert import BertConfig
-            from transformers.models.bert.modeling_bert import BertModel
         except ImportError:
             raise ImportError(
-                "Install base_models optional_dependency to use DNABERTS."
+                "Install base_models optional_dependency to use DNABERT-S."
             )
 
         if model_version != "dnabert-s":
             raise ValueError("Only dnabert-s model version available.")
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            "zhihan1996/DNABERT-S",
+            "quietflamingo/dnaberts-no-flashattention",
             trust_remote_code=True,
-            cache_dir=get_model_weights_path()
-        )
-
-        config = BertConfig.from_pretrained(
-            "zhihan1996/DNABERT-S",
             cache_dir=get_model_weights_path()
         )
 
         self.model = AutoModel.from_pretrained(
-            "zhihan1996/DNABERT-S",
+            "quietflamingo/dnaberts-no-flashattention",
             trust_remote_code=True,
-            cache_dir=get_model_weights_path(),
-            config=config
+            cache_dir=get_model_weights_path()
         ).to(self.device)
-
-        # Reset AutoModel mapping to use default BertConfig for scenarios
-        # where additional non-DNABERT loading occurs.
-        AutoModel._model_mapping.register(BertConfig, BertModel, exist_ok=True)
 
     def embed_sequence(
         self,
         sequence: str,
         agg_fn: Callable = torch.mean
     ) -> torch.Tensor:
-        """Embed sequence using DNABERTS.
+        """Embed sequence using DNABERT-S.
 
         Args:
             sequence: Sequence to embed.
             agg_fn: Method used to aggregate across sequence dimension.
 
         Returns:
-            DNABERTS representation of sequence with shape (1 x 768).
+            DNABERT-S representation of sequence with shape (1 x 768).
         """
         inputs = self.tokenizer(sequence, return_tensors="pt")["input_ids"]
         inputs = inputs.to(self.device)
@@ -90,4 +78,4 @@ class DNABERTS(EmbeddingModel):
 
     def embed_sequence_sixtrack(self, sequence, cds, splice, agg_fn):
         """Not supported."""
-        raise NotImplementedError("Six track not available for DNABERT.")
+        raise NotImplementedError("Six track not available for DNABERT-S.")

--- a/mrna_bench/models/naive_baseline.py
+++ b/mrna_bench/models/naive_baseline.py
@@ -29,13 +29,14 @@ class NaiveBaseline(EmbeddingModel):
         alphabet: str = "ACGT"
     ) -> list[str]:
         """Generate k-mer vocabulary in the given range.
+
         Args:
             kmer_list: List of k-mer lengths to generate.
             alphabet: Alphabet to use for generating k-mers.
+
         Returns:
             List of k-mers in the given range.
         """
-
         kmers: list[str] = []
         for k in sorted(kmer_list):
             kmers.extend(

--- a/mrna_bench/models/orthrus.py
+++ b/mrna_bench/models/orthrus.py
@@ -71,6 +71,12 @@ class Orthrus(EmbeddingModel):
                 "Inference currently does not support alternative aggregation."
             )
 
+        if self.is_sixtrack:
+            raise ValueError((
+                "Currently loaded model is six track."
+                "Use embed_sequence_sixtrack instead."
+            ))
+
         ohe_sequence = self.model.seq_to_oh(sequence).to(self.device)
         model_input_tt = ohe_sequence.unsqueeze(0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,14 @@ base_models = [
     "mamba-ssm==1.2.0.post1",
     "rna-fm==0.2.2",
     "accelerate",
-    "multimolecule"
+    "multimolecule",
+    "modelgenerator==0.1.1-4"
 ]
 dev = [
     "mypy",
     "flake8",
-    "flake8-docstrings"
+    "flake8-docstrings",
+    "pytest"
 ]
 
 [build-system]

--- a/scripts/linear_probe/by_embname.py
+++ b/scripts/linear_probe/by_embname.py
@@ -23,11 +23,8 @@ if __name__ == "__main__":
     prober = (
         LinearProbeBuilder(args.dataset_name)
         .fetch_embedding_by_filename(args.embedding_fn)
-        .build_splitter(
-            args.split_type,
-            eval_all_splits=True,
-            species=["human"])
-        .build_evaluator(args.task)
+        .build_splitter(args.split_type, species="human")
+        .build_evaluator(args.task, eval_all_splits=True)
         .set_target(args.target_col)
         .use_persister()
         .build()

--- a/scripts/linear_probe/by_modelname.py
+++ b/scripts/linear_probe/by_modelname.py
@@ -35,11 +35,8 @@ if __name__ == "__main__":
         .fetch_embedding_by_model_name(
             model_short_name,
             args.seq_chunk_overlap)
-        .build_splitter(
-            args.split_type,
-            eval_all_splits=True,
-            species=["human"])
-        .build_evaluator(args.task)
+        .build_splitter(args.split_type, species="human")
+        .build_evaluator(args.task, eval_all_splits=True)
         .set_target(args.target)
         .use_persister()
         .build()

--- a/tests/linear_probe/test_linear_probe_builder.py
+++ b/tests/linear_probe/test_linear_probe_builder.py
@@ -56,7 +56,6 @@ def test_fetch_embedding_instance(mock_builder: LinearProbeBuilder):
 
         assert mock_builder.model_short_name == "test_model"
         assert mock_builder.embeddings is not None
-        assert mock_builder.seq_chunk_overlap == 0
 
 
 def test_fetch_embedding_model_name(mock_builder: LinearProbeBuilder):
@@ -68,12 +67,11 @@ def test_fetch_embedding_model_name(mock_builder: LinearProbeBuilder):
 
         assert mock_builder.model_short_name == "test_model"
         assert mock_builder.embeddings is not None
-        assert mock_builder.seq_chunk_overlap == 0
 
 
 def test_fetch_embedding_file_name(mock_builder: LinearProbeBuilder):
     """Check that fetch functions set embeddings and model names."""
-    embedding_fn = "dataset_model-name_o10.npz"
+    embedding_fn = "dataset_model-name.npz"
 
     with patch.object(LinearProbeBuilder, "load_persisted_embeddings") as mock:
         mock.return_value = np.zeros((10, 10))
@@ -82,7 +80,6 @@ def test_fetch_embedding_file_name(mock_builder: LinearProbeBuilder):
 
         assert mock_builder.model_short_name == "model-name"
         assert mock_builder.embeddings is not None
-        assert mock_builder.seq_chunk_overlap == 10
 
 
 def test_build_splitter(mock_builder: LinearProbeBuilder):
@@ -138,7 +135,6 @@ def test_build(mock_builder: LinearProbeBuilder):
     """Check that build returns a LinearProbe instance."""
     mock_builder.embeddings = Mock()
     mock_builder.model_short_name = "test_model"
-    mock_builder.seq_chunk_overlap = 0
     mock_builder.target_col = "target"
     mock_builder.task = "task"
     mock_builder.splitter = Mock()

--- a/tests/models/test_aido.py
+++ b/tests/models/test_aido.py
@@ -1,0 +1,33 @@
+from collections import namedtuple
+
+import pytest
+from unittest.mock import patch
+
+pytest.importorskip("torch")
+pytest.importorskip("modelgenerator")
+
+import torch
+
+from mrna_bench.models.aido import AIDORNA
+
+
+@pytest.fixture(scope="module")
+def device() -> torch.device:
+    """Get torch cuda device if available, else use cpu."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    return torch.device(device)
+
+
+@pytest.fixture(scope="module")
+def aidorna(device) -> AIDORNA:
+    """Get AIDO.RNA model."""
+    return AIDORNA("aido_rna_650m", device)
+
+
+def test_aidorna_forward(aidorna):
+    """Test AIDO.RNA forward pass."""
+    assert aidorna.is_sixtrack is False
+
+    text = "ACTTGGCCA"
+    output = aidorna.embed_sequence(text)
+    assert output.shape == (1, 1280)


### PR DESCRIPTION
Various minor fixes to bring v1.2.0 closer to release state.

Changes:

- Linting fixes
- Code cleanup: finished removing`list[str] species` and `seq_chunk_overlap` references.
- Added handling in splitting logic to handle empty splits.
- Prevented Orthrus access to four track encoding with six track model (Temporary?)
- Added AIDO support in `base_models` installation and testing.
- Switched DNABERT2 and DNABERT-S to non-triton blocking rehosted version.
- Fixed major bug in LinearProbeBuilder which used incorrect argument order for persister.