### PR TITLE
Embedder, NaiveBaseline, Evo2 bug fixes

### DIFF
--- a/mrna_bench/embedder/dataset_embedder.py
+++ b/mrna_bench/embedder/dataset_embedder.py
@@ -112,26 +112,25 @@ class DatasetEmbedder:
         processed_files_paths = []
         processed_chunk_inds = []
 
+        glob_pattern = "{}_{}_*.npz".format(
+            self.dataset.dataset_name,
+            self.model.short_name
+        )
+
         # Check that all chunks are processed
-        for file in Path(self.dataset.embedding_dir).iterdir():
+        for file in Path(self.dataset.embedding_dir).glob(glob_pattern):
             if not file.is_file():
                 continue
 
-            file_name = file.stem
-            file_name_arr = file_name.split("_")
+            file_name_arr = file.stem.split("_")
+            if len(file_name_arr) < 3:
+                continue  # merged file, skip
 
-            if file_name_arr[0] != self.dataset.dataset_name:
-                continue
-            if file_name_arr[1] != self.model.short_name:
-                continue
-            if int(file_name_arr[2][1:]) != self.s_chunk_overlap:
+            start, end = map(int, file_name_arr[2].split("-"))
+            if end != self.d_num_chunks:
                 continue
 
-            chunk_coords = file_name_arr[3].split("-")
-            if int(chunk_coords[-1]) != self.d_num_chunks:
-                continue
-
-            processed_chunk_inds.append(int(chunk_coords[0]))
+            processed_chunk_inds.append(start)
             processed_files_paths.append(file)
 
         if len(set(all_chunks) - set(processed_chunk_inds)) > 0:

--- a/mrna_bench/models/evo2.py
+++ b/mrna_bench/models/evo2.py
@@ -113,8 +113,8 @@ class Evo2(EmbeddingModel):
             layer_chunks = [
                 embedding_chunks[i][layer_name] for i in range(n_chunks)
             ]
-            mean_chunks = torch.mean(torch.cat(layer_chunks, dim=1), dim=1)
-            aggregate_embeddings.append(mean_chunks.float().cpu())
+            agg_chunks = agg_fn(torch.cat(layer_chunks, dim=1), dim=1)
+            aggregate_embeddings.append(agg_chunks.float().cpu())
 
         # concatenate the embeddings across the layers
         aggregate_embedding = torch.cat(aggregate_embeddings, dim=1)

--- a/mrna_bench/models/naive_baseline.py
+++ b/mrna_bench/models/naive_baseline.py
@@ -142,17 +142,22 @@ class NaiveBaseline(EmbeddingModel):
         embedding = self.embed_sequence(sequence).squeeze(0)
 
         # 3. Compute cds length
-        # last 1 index + 3 to include the end of the last codon
-        cds_end = np.where(cds == 1)[0][-1] + 3
+        cds_positions = np.where(cds == 1)[0]
+        if cds_positions.size == 0:
+            cds_length = torch.tensor(
+                0.0,
+                dtype=torch.float32
+            ).unsqueeze(0)
+        else:
+            # last 1 index + 3 to include the end of the last codon
+            cds_end = cds_positions[-1] + 3
 
-        # start of first codon
-        cds_start = np.where(cds == 1)[0][0]
-
-        cds_length = cds_end - cds_start
-        cds_length = torch.tensor(
-            cds_length,
-            dtype=torch.float32
-        ).unsqueeze(0)
+            # start of first codon
+            cds_start = cds_positions[0]
+            cds_length = torch.tensor(
+                cds_end - cds_start,
+                dtype=torch.float32
+            ).unsqueeze(0)
 
         # 4. Compute exon count
         exon_count = np.sum(splice)


### PR DESCRIPTION
1. removed ref to seq_chunk_overlap + simplified logic in dataset embedder
2. bug fix for empty cds in naive baseline
3. use agg_fn for evo2 rather than hardcoded torch.mean